### PR TITLE
added cname to gh action

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -43,3 +43,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          cname: integrators.vertica.com


### PR DESCRIPTION
CNAME field was blank after every build workflow because I forgot to add its value to the .yaml file after we registered the DNS. That is corrected.